### PR TITLE
Added the ARC SPI controllers interface.

### DIFF
--- a/examples/ARC_SPI/BMI160/BMI160.ino
+++ b/examples/ARC_SPI/BMI160/BMI160.ino
@@ -1,0 +1,56 @@
+// Copyright (c) 2016 Intel Corporation.  All rights reserved.
+// See the bottom of this file for the license terms.
+
+/*
+ *  This sketch is to demonstrate SPI reading from a BMI160 device, as a bus master.  It first makes a request to
+ *  read the chip id from the device, the returned chip id should be 0xD1. Then proceed with reading out one byte at a time and dump in onto the serial term
+ *  for display, in hex.  The sketch continue doing the above steps.  If the read chip is not 0xD1, please check
+ *  the connection to the external device:  verify the signals, make sure the board and the device share a
+ *  common ground connection.
+ *
+ *  Please note:
+ *    1. This sketch makes use of ARC_SPI0.  One of the two SPI connections from the ARC core.  For the QUARK core SPI
+ *       connection, please refer to the SPI library.
+ *    2. The ARC_SPI0 connections are not available in the Arduino 101 hardware platform.
+ */
+
+// inslude the SPI library:
+#include <ARC_SPI.h>
+
+void setup()
+{
+  uint8_t dummy_reg = 0x7F;
+
+  Serial.begin(9600);  // start serial for output
+  while(!Serial);
+
+  ARC_SPI0.begin(); // initialize SPI:
+  ARC_SPI0.transfer(dummy_reg);
+}
+
+void loop()
+{
+  Serial.println("Read the BMI160 chip id, should be 0xD1"); // print the character
+  uint8_t chip_id = ARC_SPI1.transfer(0x80);
+  Serial.println(chip_id, HEX); // print the character
+  delay(1000);
+}
+
+/*
+   Copyright (c) 2016 Intel Corporation.  All rights reserved.
+
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+*/

--- a/src/ARC_SPI.cpp
+++ b/src/ARC_SPI.cpp
@@ -1,0 +1,64 @@
+/*
+ * ARC_SPI.cpp is developed based upon the Wire.cpp module.
+ *
+ * TwoWire.h - TWI/I2C library for Linux Userspace
+ * Copyright (c) 2013 Parav https://github.com/meanbot.
+ * All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Modifications to support Intel Arduino 101
+ * Copyright (C) 2015 Intel Corporation
+ *
+ * Modifications made to support the two SPI connections of the ARC core
+ * Copyright (C) 2016 Intel Corporation
+ */
+
+#include "ARC_SPI.h"
+
+void ARC_SPI::begin()
+{
+    ss_spi_init(controller_id, 2000, SPI_BUSMODE_0, SPI_8_BIT, SPI_SE_1);
+}
+
+void ARC_SPI::end()
+{
+    ss_spi_disable(controller_id);
+}
+
+void ARC_SPI::beginTransaction(SPISettings settings)
+{
+    ss_spi_init(controller_id, settings.speedMaximum / 1000, settings.dataMode, SPI_8_BIT, SPI_SE_1);
+}
+
+uint8_t ARC_SPI::transfer(uint8_t data)
+{
+    uint8_t buffer[1];
+    buffer[0] = data;
+    ss_spi_xfer(controller_id, buffer, 1, 1);
+    return buffer[0];
+}
+
+void ARC_SPI::setClockDivider(uint8_t clockDiv)
+{
+    ss_spi_set_clock_divider(controller_id, clockDiv);
+}
+
+void ARC_SPI::setDataMode(uint8_t dataMode)
+{
+    ss_spi_set_data_mode(controller_id, dataMode);
+}
+
+ARC_SPI ARC_SPI0 = ARC_SPI(SPI_SENSING_0);

--- a/src/ARC_SPI.h
+++ b/src/ARC_SPI.h
@@ -1,0 +1,85 @@
+/*
+ * ARC_SPI.h is developed based upon the TwoWire.h module.
+ *
+ * TwoWire.h - TWI/I2C library for Linux Userspace
+ * Copyright (c) 2013 Parav https://github.com/meanbot.
+ * All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Modifications made to support the two SPI connections of the ARC core
+ * Copyright (C) 2016 Intel Corporation
+ */
+
+#ifndef _ARC_SPI_H_
+#define _ARC_SPI_H_
+
+#include "ss_spi.h"
+
+#define LSBFIRST 0
+#define MSBFIRST 1
+#define SPI_MODE0 0x00
+#define SPI_MODE1 0x01
+#define SPI_MODE2 0x02
+#define SPI_MODE3 0x03
+
+class SPISettings
+{
+  public:
+    SPISettings(uint32_t _speedMaximum, uint8_t _dataOrder, uint8_t _dataMode)
+        : speedMaximum(_speedMaximum), dataOrder(_dataOrder),
+          dataMode((SPI_BUS_MODE)_dataMode)
+    {
+    }
+
+    SPISettings()
+    {
+        SPISettings(2000000, MSBFIRST, SPI_MODE0);
+    }
+
+  private:
+    uint32_t speedMaximum;
+    uint8_t dataOrder;
+    SPI_BUS_MODE dataMode;
+    friend class ARC_SPI;
+};
+
+class ARC_SPI
+{
+public:
+    ARC_SPI(SPI_CONTROLLER _controller_id) : controller_id(_controller_id)
+    {
+    }
+
+    void begin();
+    void end();
+
+    void beginTransaction(SPISettings settings);
+    //void endTransaction(void);
+
+    //void setBitOrder(uint8_t bitOrder) void setClockDivider(uint8_t clockDiv);
+    void setDataMode(uint8_t dataMode);
+    void setClockDivider(uint8_t clockDiv);
+
+    uint8_t transfer(uint8_t data);
+    //uint16_t transfer16(uint16_t data);
+    //void transfer(void *buf, size_t count);
+
+  private:
+    SPI_CONTROLLER controller_id;
+};
+extern ARC_SPI ARC_SPI0;
+
+#endif


### PR DESCRIPTION
@SidLeung 
since we don't have any SPI slave device and we don't solder out the SPI pin for tinyTILE, so I just use SS_SPI1 for test, it can read the BMI160 chip id successfully.
